### PR TITLE
feat: Improve dark mode and feature flag handling

### DIFF
--- a/app/components/features/index.tsx
+++ b/app/components/features/index.tsx
@@ -6,7 +6,7 @@ import {Code, GitBranch, Globe, LayoutDashboard, Shield, Zap} from "lucide-react
 export const Features = () => {
   const {is} = useFlags()
 
-  if (!is("features").enabled()) return null
+  if (is("features").disabled()) return null
 
   return (
     <section id="features" className="bg-muted/50 py-20">

--- a/app/components/header/theme/index.tsx
+++ b/app/components/header/theme/index.tsx
@@ -8,7 +8,7 @@ export const Theme = () => {
   const {is} = useFlags();
   const [_, setTheme] = useAtom(themeAtom)
 
-  if (!is("darkmode").enabled()) return null
+  if (is("darkmode").disabled()) return null
 
   return (
     <DropdownMenu>

--- a/app/components/hero/index.tsx
+++ b/app/components/hero/index.tsx
@@ -9,7 +9,7 @@ import {siteConfig} from "~/appconfig";
 export const Hero = () => {
   const {is} = useFlags()
 
-  if (!is("hero").enabled()) return null
+  if (is("hero").disabled()) return null
 
   return (
     <section className="py-20 md:py-28">

--- a/app/components/how-it-works/index.tsx
+++ b/app/components/how-it-works/index.tsx
@@ -4,10 +4,10 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs"
 import {Card, CardContent, CardDescription, CardHeader, CardTitle} from "../ui/card"
 
 export const HowItWorks = () => {
-  const {is} = useFlags()
-  is("tester").initialize(false)
+  const {initialize, is} = useFlags()
+  initialize("tester", false)
 
-  if (!is("how it works").enabled()) return null
+  if (is("how it works").disabled()) return null
 
   return (
     <section id="how-it-works" className="py-20">
@@ -55,9 +55,13 @@ export const HowItWorks = () => {
                   <CardDescription>Define your feature flags in our dashboard with a few clicks.</CardDescription>
                 </CardHeader>
                 <CardContent>
-                  <div className="rounded-md bg-muted p-4 w-full">
-                    Alternatively if you want an offline flag <br />
-                    <code className="text-sm">is("tester").initialize(false)</code>
+                  Alternatively if you want an offline flag:
+                  <div className="rounded-md bg-muted p-2 w-full mt-2">
+                    <code className="text-sm">
+                      {"const {initialize} = useFlags()"}
+                      <br />
+                      {"initialize(\"tester\", false)"}
+                    </code>
                   </div>
                 </CardContent>
               </Card>
@@ -73,7 +77,11 @@ export const HowItWorks = () => {
                 <CardContent>
                   <div className="rounded-md bg-muted p-4 w-full">
                     <code className="text-sm">
-                      {"if (is('newFeature').enabled()) {\n  // Show new feature\n}"}
+                      {"const {is} = useFlags()"}
+                      <br />
+                      {"if (is('newFeature').enabled()) {"}<br />
+                      {"// Show new feature"}<br />
+                      {"}"}
                     </code>
                   </div>
                 </CardContent>

--- a/app/components/pricing/index.tsx
+++ b/app/components/pricing/index.tsx
@@ -8,7 +8,7 @@ import {EnterpriseTier} from "~/components/pricing/enterprise";
 export const Pricing = () => {
   const {is} = useFlags()
 
-  if (!is("pricing").enabled()) return null
+  if (is("pricing").disabled()) return null
 
   return (
     <section id="pricing" className="py-20">

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "typecheck": "react-router typegen && tsc"
   },
   "dependencies": {
-    "@flags-gg/react-library": "^1.12.2",
+    "@flags-gg/react-library": "^1.14.0",
     "@radix-ui/react-dialog": "^1.1.13",
     "@radix-ui/react-dropdown-menu": "^2.1.14",
     "@radix-ui/react-separator": "^1.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@flags-gg/react-library':
-        specifier: ^1.12.2
-        version: 1.12.2(@types/react@19.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^1.14.0
+        version: 1.14.0(@types/react@19.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-dialog':
         specifier: ^1.1.13
         version: 1.1.13(@types/react-dom@19.1.3(@types/react@19.1.3))(@types/react@19.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -378,8 +378,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@flags-gg/react-library@1.12.2':
-    resolution: {integrity: sha512-DAs2V7ziAVWHuhpSnr505sgwW5rJZja5KPGJhvJLTbY/vv76a+M999Xv2wqq0/3/tKWjBAmvwDKzTJ3I0cPv5g==}
+  '@flags-gg/react-library@1.14.0':
+    resolution: {integrity: sha512-jKXfyNL0sNF2YBH0FQPbrnqMlVx0IUOFGmrEWRMKzO0w1QsduUT5OPka2CgwsS+1NmofbsfVmJXre9I51n0w0A==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -1476,11 +1476,6 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
-  lucide-react@0.487.0:
-    resolution: {integrity: sha512-aKqhOQ+YmFnwq8dWgGjOuLc8V1R9/c/yOd+zDY4+ohsR2Jo05lSGc3WsstYPIzcTpeosN7LoCkLReUUITvaIvw==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   lucide-react@0.508.0:
     resolution: {integrity: sha512-gcP16PnexqtOFrTtv98kVsGzTfnbPekzZiQfByi2S89xfk7E/4uKE1USZqccIp58v42LqkO7MuwpCqshwSrJCg==}
     peerDependencies:
@@ -2287,12 +2282,12 @@ snapshots:
   '@esbuild/win32-x64@0.25.4':
     optional: true
 
-  '@flags-gg/react-library@1.12.2(@types/react@19.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@flags-gg/react-library@1.14.0(@types/react@19.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@swc/helpers': 0.5.17
       fast-equals: 5.2.2
       jotai: 2.12.4(@types/react@19.1.3)(react@19.1.0)
-      lucide-react: 0.487.0(react@19.1.0)
+      lucide-react: 0.508.0(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     transitivePeerDependencies:
@@ -3348,10 +3343,6 @@ snapshots:
       yallist: 3.1.1
 
   lru-cache@7.18.3: {}
-
-  lucide-react@0.487.0(react@19.1.0):
-    dependencies:
-      react: 19.1.0
 
   lucide-react@0.508.0(react@19.1.0):
     dependencies:


### PR DESCRIPTION
- Update the `Theme` component to only render when dark mode is enabled
- Upgrade the `@flags-gg/react-library` dependency to version 1.14.0
- Update the `HowItWorks` component to show a better example of initializing an offline flag
- Update the `Pricing` and `Features` components to only render when their respective feature flags are enabled
- Update the `pnpm-lock.yaml` file to reflect the dependency changes