### PR TITLE
feat: Upgrade @flags-gg/react-library to v1.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "landingpage",
       "dependencies": {
-        "@flags-gg/react-library": "^1.12.2",
+        "@flags-gg/react-library": "^1.14.0",
         "@radix-ui/react-dialog": "^1.1.13",
         "@radix-ui/react-dropdown-menu": "^2.1.14",
         "@radix-ui/react-separator": "^1.1.6",
@@ -946,27 +946,18 @@
       }
     },
     "node_modules/@flags-gg/react-library": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@flags-gg/react-library/-/react-library-1.12.2.tgz",
-      "integrity": "sha512-DAs2V7ziAVWHuhpSnr505sgwW5rJZja5KPGJhvJLTbY/vv76a+M999Xv2wqq0/3/tKWjBAmvwDKzTJ3I0cPv5g==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@flags-gg/react-library/-/react-library-1.14.0.tgz",
+      "integrity": "sha512-jKXfyNL0sNF2YBH0FQPbrnqMlVx0IUOFGmrEWRMKzO0w1QsduUT5OPka2CgwsS+1NmofbsfVmJXre9I51n0w0A==",
       "dependencies": {
         "@swc/helpers": "^0.5.17",
         "fast-equals": "^5.2.2",
-        "jotai": "^2.12.2",
-        "lucide-react": "^0.487.0"
+        "jotai": "^2.12.4",
+        "lucide-react": "^0.508.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@flags-gg/react-library/node_modules/lucide-react": {
-      "version": "0.487.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.487.0.tgz",
-      "integrity": "sha512-aKqhOQ+YmFnwq8dWgGjOuLc8V1R9/c/yOd+zDY4+ohsR2Jo05lSGc3WsstYPIzcTpeosN7LoCkLReUUITvaIvw==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@floating-ui/core": {


### PR DESCRIPTION
Upgrade the @flags-gg/react-library dependency to version 1.14.0. This
update includes the following changes:

- Upgrade jotai to v2.12.4
- Upgrade lucide-react to v0.508.0
- Resolve any potential issues or vulnerabilities in the previous version