### PR TITLE
feat(docker): migrate to pnpm and enable corepack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,26 @@
 FROM node:20-alpine AS development-dependencies-env
 COPY . /app
 WORKDIR /app
-RUN npm ci
+RUN corepack enable
+RUN pnpm install --frozen-lockfile
 
 FROM node:20-alpine AS production-dependencies-env
-COPY ./package.json package-lock.json /app/
+COPY ./package.json pnpm-lock.yaml /app/
 WORKDIR /app
-RUN npm ci --omit=dev
+RUN corepack enable
+RUN pnpm install --frozen-lockfile --prod
 
 FROM node:20-alpine AS build-env
 COPY . /app/
 COPY --from=development-dependencies-env /app/node_modules /app/node_modules
 WORKDIR /app
-RUN npm run build
+RUN corepack enable
+RUN pnpm build
 
 FROM node:20-alpine
-COPY ./package.json package-lock.json /app/
+COPY ./package.json pnpm-lock.yaml /app/
 COPY --from=production-dependencies-env /app/node_modules /app/node_modules
 COPY --from=build-env /app/build /app/build
 WORKDIR /app
-CMD ["npm", "run", "start"]
+RUN corepack enable
+CMD ["pnpm", "start"]


### PR DESCRIPTION
Migrate the Dockerfile to use pnpm instead of npm for dependency
management. Enable corepack to simplify the pnpm installation process.
These changes improve the build performance and consistency of the
Docker image.